### PR TITLE
fix docs CI error - v3 is deprecated

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build Docs
         run: make -C docs/ html
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.REPOSITORY_NAME }}-docs
           path: docs/build/html/


### PR DESCRIPTION
Fixing the deprecated upload-artifact version to v4