### PR TITLE
Remove python 3.9 support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         host-os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     defaults:

--- a/examples/bluesky_adaptive_agent.py
+++ b/examples/bluesky_adaptive_agent.py
@@ -1,5 +1,5 @@
-from collections.abc import Sequence
-from typing import Any, Callable, Optional
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import pandas as pd
 from bluesky_adaptive.agents.base import Agent as BlueskyAdaptiveBaseAgent  # type: ignore[import-untyped]
@@ -23,7 +23,7 @@ class BlueskyAdaptiveAgent(BlueskyAdaptiveBaseAgent, BlopAgent):
         sequential: bool,
         upsample: int,
         acqf_kwargs: dict[str, Any],
-        detector_names: Optional[list[str]] = None,
+        detector_names: list[str] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -116,9 +116,9 @@ class BlueskyAdaptiveAgent(BlueskyAdaptiveBaseAgent, BlopAgent):
         points: dict[str, list[ArrayLike]] = default_result.pop("points")
         acqf_obj: list[ArrayLike] = default_result.pop("acqf_obj")
         # Turn dict of list of points into list of consistently sized points
-        points: list[tuple[ArrayLike]] = list(zip(*[value for _, value in points.items()]))
+        points: list[tuple[ArrayLike]] = list(zip(*[value for _, value in points.items()], strict=False))
         dicts = []
-        for point, obj in zip(points, acqf_obj):
+        for point, obj in zip(points, acqf_obj, strict=False):
             d = default_result.copy()
             d["point"] = point
             d["acqf_obj"] = obj
@@ -126,8 +126,8 @@ class BlueskyAdaptiveAgent(BlueskyAdaptiveBaseAgent, BlopAgent):
         return points, dicts
 
     def tell(self, x: dict[str, ArrayLike], y: dict[str, ArrayLike]):
-        x = {key: x_i for x_i, key in zip(x, self.dofs.names)}
-        y = {key: y_i for y_i, key in zip(y, self.objectives.names)}
+        x = {key: x_i for x_i, key in zip(x, self.dofs.names, strict=False)}
+        y = {key: y_i for y_i, key in zip(y, self.objectives.names, strict=False)}
         super().tell(data={**x, **y})
         return {**x, **y}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 maintainers = [
   { name = "Brookhaven National Laboratory", email = "tmorris@bnl.gov" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "area-detector-handlers",
   "bluesky",
@@ -21,7 +21,7 @@ dependencies = [
   "gpytorch",
   "h5py",
   "matplotlib",
-  "numpy<2",
+  "numpy",
   "ophyd",
   "ortools",
   "scipy",

--- a/src/blop/bayesian/acquisition/__init__.py
+++ b/src/blop/bayesian/acquisition/__init__.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import yaml
@@ -29,7 +29,7 @@ def all_acqfs(columns: tuple[str, ...] = ("identifier", "type", "multitask_only"
     return acqfs.sort_values(["type", "name"])
 
 
-def parse_acqf_identifier(identifier: str, strict: bool = True) -> Optional[dict[str, Any]]:
+def parse_acqf_identifier(identifier: str, strict: bool = True) -> dict[str, Any] | None:
     for acqf_name in config.keys():
         if identifier.lower() in [acqf_name, config[acqf_name]["identifier"]]:
             return {"name": acqf_name, **config[acqf_name]}

--- a/src/blop/bayesian/acquisition/analytic.py
+++ b/src/blop/bayesian/acquisition/analytic.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import torch

--- a/src/blop/bayesian/acquisition/monte_carlo.py
+++ b/src/blop/bayesian/acquisition/monte_carlo.py
@@ -1,5 +1,5 @@
 import math
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import torch

--- a/src/blop/bayesian/kernels.py
+++ b/src/blop/bayesian/kernels.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from typing import Union
 
 import gpytorch  # type: ignore[import-untyped]
 import numpy as np
@@ -14,7 +13,7 @@ class LatentKernel(gpytorch.kernels.Kernel):
     def __init__(
         self,
         num_inputs: int = 1,
-        skew_dims: Union[bool, Iterable[tuple[int, ...]]] = True,
+        skew_dims: bool | Iterable[tuple[int, ...]] = True,
         priors: bool = True,
         scale_output: bool = True,
         **kwargs,
@@ -109,7 +108,7 @@ class LatentKernel(gpytorch.kernels.Kernel):
         return self.raw_lengthscales_constraint.transform(self.raw_lengthscales)
 
     @lengthscales.setter
-    def lengthscales(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def lengthscales(self, value: torch.Tensor | float | np.ndarray) -> None:
         self._set_lengthscales(value)
 
     @property
@@ -117,7 +116,7 @@ class LatentKernel(gpytorch.kernels.Kernel):
         return self.raw_skew_entries_constraint.transform(self.raw_skew_entries)
 
     @skew_entries.setter
-    def skew_entries(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def skew_entries(self, value: torch.Tensor | float | np.ndarray) -> None:
         self._set_skew_entries(value)
 
     @property
@@ -125,20 +124,20 @@ class LatentKernel(gpytorch.kernels.Kernel):
         return self.raw_outputscale_constraint.transform(self.raw_outputscale)
 
     @outputscale.setter
-    def outputscale(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def outputscale(self, value: torch.Tensor | float | np.ndarray) -> None:
         self._set_outputscale(value)
 
-    def _set_lengthscales(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def _set_lengthscales(self, value: torch.Tensor | float | np.ndarray) -> None:
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_lengthscales)
         self.initialize(raw_lengthscales=self.raw_lengthscales_constraint.inverse_transform(value))
 
-    def _set_skew_entries(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def _set_skew_entries(self, value: torch.Tensor | float | np.ndarray) -> None:
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_skew_entries)
         self.initialize(raw_skew_entries=self.raw_skew_entries_constraint.inverse_transform(value))
 
-    def _set_outputscale(self, value: Union[torch.Tensor, float, np.ndarray]) -> None:
+    def _set_outputscale(self, value: torch.Tensor | float | np.ndarray) -> None:
         if not torch.is_tensor(value):
             value = torch.as_tensor(value).to(self.raw_outputscale)
         self.initialize(raw_outputscale=self.raw_outputscale_constraint.inverse_transform(value))

--- a/src/blop/bayesian/models.py
+++ b/src/blop/bayesian/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 import botorch  # type: ignore[import-untyped]
 import gpytorch  # type: ignore[import-untyped]
@@ -10,7 +10,7 @@ from . import kernels
 
 def train_model(
     model: SingleTaskGP,
-    hypers: Optional[dict[str, Any]] = None,
+    hypers: dict[str, Any] | None = None,
     max_fails: int = 4,
     **kwargs: Any,
 ) -> None:
@@ -34,7 +34,7 @@ def train_model(
 def construct_single_task_model(
     X: torch.Tensor,
     y: torch.Tensor,
-    skew_dims: Optional[list[tuple[int, ...]]] = None,
+    skew_dims: list[tuple[int, ...]] | None = None,
     min_noise: float = 1e-6,
     max_noise: float = 1e0,
 ) -> "LatentGP":
@@ -74,7 +74,7 @@ class LatentGP(SingleTaskGP):
         self,
         train_inputs: torch.Tensor,
         train_targets: torch.Tensor,
-        skew_dims: Union[bool, list[tuple[int, ...]]] = True,
+        skew_dims: bool | list[tuple[int, ...]] = True,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -99,7 +99,7 @@ class LatentConstraintModel(LatentGP):
         self,
         train_inputs: torch.Tensor,
         train_targets: torch.Tensor,
-        skew_dims: Union[bool, list[tuple[int, ...]]] = True,
+        skew_dims: bool | list[tuple[int, ...]] = True,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -121,7 +121,7 @@ class LatentDirichletClassifier(LatentGP):
         self,
         train_inputs: torch.Tensor,
         train_targets: torch.Tensor,
-        skew_dims: Union[bool, list[tuple[int, ...]]] = True,
+        skew_dims: bool | list[tuple[int, ...]] = True,
         *args: Any,
         **kwargs: Any,
     ) -> None:

--- a/src/blop/de/de_opt_utils.py
+++ b/src/blop/de/de_opt_utils.py
@@ -193,7 +193,7 @@ def generate_hardware_flyers(
             max_velocity=max_velocity,
             min_velocity=min_velocity,
         )
-        for motor_name, vel, dist in zip(motors, velocities, dists):
+        for motor_name, vel, dist in zip(motors, velocities, dists, strict=False):
             velocities_dict[motor_name] = vel
             distances_dict[motor_name] = dist
         velocities_list.append(velocities_dict)
@@ -201,7 +201,7 @@ def generate_hardware_flyers(
 
     # Validation
     times_list = []
-    for dist, vel in zip(distances_list, velocities_list):
+    for dist, vel in zip(distances_list, velocities_list, strict=False):
         times_dict = {}
         for motor_name in motors.keys():
             if vel[motor_name] == 0:
@@ -211,7 +211,7 @@ def generate_hardware_flyers(
             times_dict[motor_name] = time_
         times_list.append(times_dict)
 
-    for param, vel, time_ in zip(population, velocities_list, times_list):
+    for param, vel, time_ in zip(population, velocities_list, times_list, strict=False):
         hf = HardwareFlyer(
             params_to_change=param,
             velocities=vel,

--- a/src/blop/sim/beamline.py
+++ b/src/blop/sim/beamline.py
@@ -3,7 +3,7 @@ from collections import deque
 from collections.abc import Generator, Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import h5py  # type: ignore[import-untyped]
 import numpy as np
@@ -45,11 +45,11 @@ class Detector(Device):
 
         # Resource/datum docs related variables.
         self._asset_docs_cache: deque[tuple[str, dict[str, Any]]] = deque()
-        self._resource_document: Optional[dict[str, Any]] = None
-        self._datum_factory: Optional[Any] = None
-        self._dataset: Optional[h5py.Dataset] = None
-        self._h5file_desc: Optional[h5py.File] = None
-        self._counter: Optional[Iterator[int]] = None
+        self._resource_document: dict[str, Any] | None = None
+        self._datum_factory: Any | None = None
+        self._dataset: h5py.Dataset | None = None
+        self._h5file_desc: h5py.File | None = None
+        self._counter: Iterator[int] | None = None
 
         self.noise.put(noise)
 

--- a/src/blop/utils/__init__.py
+++ b/src/blop/utils/__init__.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import botorch  # type: ignore[import-untyped]
 import numpy as np
 import scipy as sp  # type: ignore[import-untyped]
@@ -9,7 +7,7 @@ from ortools.constraint_solver import pywrapcp, routing_enums_pb2  # type: ignor
 from . import functions  # noqa
 
 
-def get_beam_stats(image: np.ndarray, threshold: float = 0.5) -> dict[str, Union[float, np.ndarray]]:
+def get_beam_stats(image: np.ndarray, threshold: float = 0.5) -> dict[str, float | np.ndarray]:
     ny, nx = image.shape
 
     fim = image.copy()
@@ -92,7 +90,7 @@ def mprod(*M: np.ndarray) -> np.ndarray:
     return res
 
 
-def route(start_point: np.ndarray, points: np.ndarray, dim_weights: Union[float, np.ndarray] = 1) -> np.ndarray:
+def route(start_point: np.ndarray, points: np.ndarray, dim_weights: float | np.ndarray = 1) -> np.ndarray:
     """
     Returns the indices of the most efficient way to visit `points`, starting from `start_point`.
     """
@@ -138,7 +136,7 @@ def route(start_point: np.ndarray, points: np.ndarray, dim_weights: Union[float,
     return np.array(route_indices)[1:-1] - 1
 
 
-def get_movement_time(x: Union[float, np.ndarray], v_max: float, a: float) -> Union[float, np.ndarray]:
+def get_movement_time(x: float | np.ndarray, v_max: float, a: float) -> float | np.ndarray:
     """
     How long does it take an object to go distance $x$ with acceleration $a$ and maximum velocity $v_max$?
     That's what this function answers.


### PR DESCRIPTION
Based on discussion in #100 

- Python 3.9 EOL is in October 2025
- We want to be able to support any numpy version