### PR TITLE
Remove 'created' from release types

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
   build_docs:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ name: PyPI upload
 
 on:
   release:
-    types: [created, published]
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes the duplicated trigger on GitHub actions.

![Screenshot 2025-03-04 at 5 11 04 PM](https://github.com/user-attachments/assets/d0391410-2411-4202-a3f0-be29950837fb)
