### PR TITLE
Update installation.rst to reflect the version of python tested against

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation instructions
 Installation
 ------------
 
-The package works with Python 3.8+ and can be installed from both PyPI and conda-forge.
+The package works with Python 3.10+ and can be installed from both PyPI and conda-forge.
 
 To install the package using the ``pip`` package manager, run the following command:
 


### PR DESCRIPTION
bloptools is tested against python 3.10+. 

The docs stated it worked with 3.8+ but with 3.9 it doesn't work. I updated the docs to reflect this. 

https://github.com/NSLS-II/blop/blob/a23b801213b84619fb82b0bf2c0d4e245ad0ba5b/.github/workflows/testing.yml#L19